### PR TITLE
Function overridden from app settings are now using import_from_string

### DIFF
--- a/jwt_auth/settings.py
+++ b/jwt_auth/settings.py
@@ -5,28 +5,28 @@ from django.conf import settings
 from jwt_auth.utils import import_from_string
 
 
-JWT_ENCODE_HANDLER = getattr(
+JWT_ENCODE_HANDLER = import_from_string(getattr(
     settings,
     'JWT_ENCODE_HANDLER',
-    import_from_string('jwt_auth.utils.jwt_encode_handler')
+    'jwt_auth.utils.jwt_encode_handler')
 )
 
-JWT_DECODE_HANDLER = getattr(
+JWT_DECODE_HANDLER = import_from_string(getattr(
     settings,
     'JWT_DECODE_HANDLER',
-    import_from_string('jwt_auth.utils.jwt_decode_handler')
+    'jwt_auth.utils.jwt_decode_handler')
 )
 
-JWT_PAYLOAD_HANDLER = getattr(
+JWT_PAYLOAD_HANDLER = import_from_string(getattr(
     settings,
     'JWT_PAYLOAD_HANDLER',
-    import_from_string('jwt_auth.utils.jwt_payload_handler')
+    'jwt_auth.utils.jwt_payload_handler')
 )
 
-JWT_PAYLOAD_GET_USER_ID_HANDLER = getattr(
+JWT_PAYLOAD_GET_USER_ID_HANDLER = import_from_string(getattr(
     settings,
     'JWT_PAYLOAD_GET_USER_ID_HANDLER',
-    import_from_string('jwt_auth.utils.jwt_get_user_id_from_payload_handler')
+    'jwt_auth.utils.jwt_get_user_id_from_payload_handler')
 )
 
 JWT_SECRET_KEY = getattr(


### PR DESCRIPTION
When an override for the default handler function is set in the project's settings.py, the string of the path to the override function gets set as the override function.
This causes a TypeError: 'str' object is not callable error.

Function overridden from app settings are now using import_from_string
